### PR TITLE
Fix: Removed Fira Code from vars.css.

### DIFF
--- a/preview-src/index.adoc
+++ b/preview-src/index.adoc
@@ -311,6 +311,51 @@ This is a non-structural heading that you can use for the following headings:
 * Prerequisites
 * Example
 
+<6> Encoding of xref:../Smart_Contracts/class-hash.adoc[the class hash].
+<7> Encoding of the compiled class hash of the declared class.
+
+== Callouts in code examples
+
+[source,json]
+----
+[
+  1, <1>
+  2019172390095051323869047481075102003731246132997057518965927979101413600827, <2>
+  18446744073709551617, <3>
+  100, <4>
+  200, <4>
+  1, <5>
+  1351148242645005540004162531550805076995747746087542030095186557536641755046, <6>
+  558404273560404778508455254030458021013656352466216690688595011803280448032 <7>
+smile <8>
+]
+----
+<1> The first element, `1`, is the number of contracts whose state was updated.
+<2> The second element, `2019172390095051323869047481075102003731246132997057518965927979101413600827`, is the address of the first, and only, contract whose state changed.
+<3> The third element, `18446744073709551617`, which is 2^64^+1, encodes the following:
+* The class information flag is `0`, that is, the contract was not deployed or replaced just now, so you shouldn't treat the next word as the class hash.
+* The new nonce is `1`.
+* One storage cell was updated.
+<4> The next two elements, `100` and `200`, encode the storage update, where the value of key `100` is set to `200`.
+<5> the new declare section: `1` includes a single xref:Network_Architecture/transactions.adoc#declare_v2[declare v2] transaction in this state update.
+<8> text
+
+
+== System call
+
+[id="get_block_hash"]
+== `get_block_hash`
+
+[discrete]
+=== Syntax
+
+[source,cairo,subs="+quotes,+macros"]
+----
+extern fn get_block_hash_syscall(
+    block_number: u64
+) -> SyscallResult<felt252> implicits(GasBuiltin, System) nopanic;
+----
+
 == Fin
 
 That's all, folks!

--- a/src/css/vars.css
+++ b/src/css/vars.css
@@ -28,7 +28,13 @@
   --body-line-height: 2;
   --body-font-family: "Inter", sans-serif;
   --body-font-weight-bold: 500;
-  --monospace-font-family: "Fira Code", monospace;
+  --monospace-font-family: Roboto Mono,monospace;
+/* Disabled Fira Code because it was showing -> as an arrow,
+Which is actually the purpose of Fira Code. But that means that
+our code examples incorrectly show that you should use an arrow in Cairo code
+instead of ->.
+Leaving this here for now for historical purposes. */
+  /*--monospace-font-family: "Fira Code", monospace; */
   --monospace-font-weight-bold: 500;
   /* base */
   --body-background: var(--color-smoke-80);


### PR DESCRIPTION
Disabled Fira Code because it was showing -> as an arrow,
Which is actually the purpose of Fira Code. But that means that
our code examples incorrectly show that you should use an arrow in Cairo code
instead of ->.


